### PR TITLE
add config parameter exclude_uri_pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+/.idea/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Run kong reload or start and add the plugin as normal.
 ### Docker installation
 We recommend using [kong-docker by dojot](https://github.com/dojot/kong). Copy this repo into the plugins directory of that project and build a custom docker image.
 
+## Info
+
+This plugins priority is set to 1500.
+So it is handled after ip-restriction, bot-detection, cors - but before jwt and other authentication plugins
+(see last paragraph in [Kongo Plugin Documentation - Custom Logic](https://docs.konghq.com/0.14.x/plugin-development/custom-logic/)).
+
+
+
 ## Configuration
 
 * `exclude_uri_pattern`: 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then in the kong.yml add
 
 ```
 custom_plugins:
-  - http-to-https-redirect
+  - kong-http-to-https-redirect
 ```
 
 Run kong reload or start and add the plugin as normal.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Run kong reload or start and add the plugin as normal.
 We recommend using [kong-docker by dojot](https://github.com/dojot/kong). Copy this repo into the plugins directory of that project and build a custom docker image.
 
 ## Configuration
-As yet, we've had no need for any configuration. Raise an issue if there's anything you'd like to see.
+
+* `exclude_uri_pattern`: 
+    When this value is empty, then a redirect is done in every HTTP (not HTTPS) request.
+    When it is set, then the redirect to https is only done when the called URI doesn't match to the Lua pattern in `exclude_uri_pattern`.
+
+Raise an issue if there's anything more you'd like to see.
 
 ## Misc
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -3,6 +3,10 @@ local responses = require "kong.tools.responses"
 
 local HttpFilterHandler = BasePlugin:extend()
 
+-- handle redirect after ip-restriction, bot-detection, cors - but before jwt and other authentication plugins
+-- see https://docs.konghq.com/0.14.x/plugin-development/custom-logic/
+HttpFilterHandler.PRIORITY = 1500
+
 function HttpFilterHandler:new()
   HttpFilterHandler.super.new(self, "kong-http-to-https-redirect")
 end

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -11,7 +11,10 @@ function HttpFilterHandler:access(conf)
   HttpFilterHandler.super.access(self)
 
   if ngx.var.https ~= "on" then
-    return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY) 
+    local matches_exclude_pattern = conf.exclude_uri_pattern and string.find(ngx.var.request_uri, conf.exclude_uri_pattern)
+    if not matches_exclude_pattern then
+      return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
+    end
   end  
 end
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -4,7 +4,7 @@ local responses = require "kong.tools.responses"
 local HttpFilterHandler = BasePlugin:extend()
 
 function HttpFilterHandler:new()
-  HttpFilterHandler.super.new(self, "http-to-https-redirect")
+  HttpFilterHandler.super.new(self, "kong-http-to-https-redirect")
 end
 
 function HttpFilterHandler:access(conf)

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -1,5 +1,4 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 
 local HttpFilterHandler = BasePlugin:extend()
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -14,7 +14,7 @@ end
 function HttpFilterHandler:access(conf)
   HttpFilterHandler.super.access(self)
 
-  if ngx.var.https ~= "on" then
+  if ngx.var.https ~= "on" and ngx.var.http_x_forwarded_proto ~= "https" then
     local matches_exclude_pattern = conf.exclude_uri_pattern and string.find(ngx.var.request_uri, conf.exclude_uri_pattern)
     if not matches_exclude_pattern then
       return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -1,18 +1,13 @@
-local BasePlugin = require "kong.plugins.base_plugin"
+local MyPlugin = {
+  -- handle redirect after ip-restriction, bot-detection, cors - but before jwt and other authentication plugins
+  -- see https://docs.konghq.com/0.14.x/plugin-development/custom-logic/
+  PRIORITY = 1500,
+  VERSION = "1.0",
+}
 
-local HttpFilterHandler = BasePlugin:extend()
+local kong = kong
 
--- handle redirect after ip-restriction, bot-detection, cors - but before jwt and other authentication plugins
--- see https://docs.konghq.com/0.14.x/plugin-development/custom-logic/
-HttpFilterHandler.PRIORITY = 1500
-
-function HttpFilterHandler:new()
-  HttpFilterHandler.super.new(self, "kong-http-to-https-redirect")
-end
-
-function HttpFilterHandler:access(conf)
-  HttpFilterHandler.super.access(self)
-
+function MyPlugin:access(conf)
   if ngx.var.https ~= "on" and ngx.var.http_x_forwarded_proto ~= "https" then
     local matches_exclude_pattern = conf.exclude_uri_pattern and string.find(ngx.var.request_uri, conf.exclude_uri_pattern)
     if not matches_exclude_pattern then
@@ -21,4 +16,4 @@ function HttpFilterHandler:access(conf)
   end  
 end
 
-return HttpFilterHandler
+return MyPlugin

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -1,5 +1,6 @@
 return {
   no_consumer = true,
   fields = {
+    exclude_uri_pattern = {type = "string", required = false}
   }
 }

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -1,6 +1,29 @@
+-- see https://docs.konghq.com/gateway/3.4.x/plugin-development/configuration/
+-- see https://github.com/Kong/kong-plugin/blob/master/kong/plugins/myplugin/schema.lua
+
+local typedefs = require "kong.db.schema.typedefs"
+
+
 return {
-  no_consumer = true,
+  name = "kong-http-to-https-redirect",
   fields = {
-    exclude_uri_pattern = {type = "string", required = false}
-  }
+    {
+      -- this plugin will only be applied to Services or Routes
+      consumer = typedefs.no_consumer
+    },
+    {
+      -- this plugin will only run within Nginx HTTP module
+      protocols = typedefs.protocols_http
+    },
+    {
+      config = {
+        type = "record",
+        fields = {
+          {
+            exclude_uri_pattern = {type = "string", required = false},
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
I would like to be able to install this plugin globally but define the exception explicitly.

Currently, I am only able to decide whether to install the plugin on each route (this might be much work and/or redundancy) or globally. This is inconvenient. E.g. In my case I would like to install it globally - with only one exception: The URL that letsencrypt/certbot uses to validate certificates (`/.well-known/acme-challenge`).

This PR adds the ability to define the config parameter `exclude_uri_pattern`. When this value is empty, then everything is as before (backward compatibility). When it is set, then the redirect to https is only done when the called URI doesn't match to the Lua pattern in `exclude_uri_pattern`.
