### PR TITLE
Fix behaviour behind load balancer - fixes #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+/.idea/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Run kong reload or start and add the plugin as normal.
 ### Docker installation
 We recommend using [kong-docker by dojot](https://github.com/dojot/kong). Copy this repo into the plugins directory of that project and build a custom docker image.
 
+## Info
+
+This plugins priority is set to 1500.
+So it is handled after ip-restriction, bot-detection, cors - but before jwt and other authentication plugins
+(see last paragraph in [Kongo Plugin Documentation - Custom Logic](https://docs.konghq.com/0.14.x/plugin-development/custom-logic/)).
+
+
+
 ## Configuration
 
 * `exclude_uri_pattern`: 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then in the kong.yml add
 
 ```
 custom_plugins:
-  - http-to-https-redirect
+  - kong-http-to-https-redirect
 ```
 
 Run kong reload or start and add the plugin as normal.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Run kong reload or start and add the plugin as normal.
 We recommend using [kong-docker by dojot](https://github.com/dojot/kong). Copy this repo into the plugins directory of that project and build a custom docker image.
 
 ## Configuration
-As yet, we've had no need for any configuration. Raise an issue if there's anything you'd like to see.
+
+* `exclude_uri_pattern`: 
+    When this value is empty, then a redirect is done in every HTTP (not HTTPS) request.
+    When it is set, then the redirect to https is only done when the called URI doesn't match to the Lua pattern in `exclude_uri_pattern`.
+
+Raise an issue if there's anything more you'd like to see.
 
 ## Misc
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -3,6 +3,10 @@ local responses = require "kong.tools.responses"
 
 local HttpFilterHandler = BasePlugin:extend()
 
+-- handle redirect after ip-restriction, bot-detection, cors - but before jwt and other authentication plugins
+-- see https://docs.konghq.com/0.14.x/plugin-development/custom-logic/
+HttpFilterHandler.PRIORITY = 1500
+
 function HttpFilterHandler:new()
   HttpFilterHandler.super.new(self, "kong-http-to-https-redirect")
 end

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -11,7 +11,10 @@ function HttpFilterHandler:access(conf)
   HttpFilterHandler.super.access(self)
 
   if ngx.var.https ~= "on" then
-    return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY) 
+    local matches_exclude_pattern = conf.exclude_uri_pattern and string.find(ngx.var.request_uri, conf.exclude_uri_pattern)
+    if not matches_exclude_pattern then
+      return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)
+    end
   end  
 end
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -4,7 +4,7 @@ local responses = require "kong.tools.responses"
 local HttpFilterHandler = BasePlugin:extend()
 
 function HttpFilterHandler:new()
-  HttpFilterHandler.super.new(self, "http-to-https-redirect")
+  HttpFilterHandler.super.new(self, "kong-http-to-https-redirect")
 end
 
 function HttpFilterHandler:access(conf)

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -14,7 +14,7 @@ end
 function HttpFilterHandler:access(conf)
   HttpFilterHandler.super.access(self)
 
-  if ngx.var.https ~= "on" then
+  if ngx.var.https ~= "on" and ngx.var.http_x_forwarded_proto ~= "https" then
     local matches_exclude_pattern = conf.exclude_uri_pattern and string.find(ngx.var.request_uri, conf.exclude_uri_pattern)
     if not matches_exclude_pattern then
       return ngx.redirect("https://" .. ngx.var.host .. ngx.var.request_uri, ngx.HTTP_MOVED_PERMANENTLY)

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -1,5 +1,6 @@
 return {
   no_consumer = true,
   fields = {
+    exclude_uri_pattern = {type = "string", required = false}
   }
 }


### PR DESCRIPTION
If Kong is behind a load balancer a check for https is not enough because it's always off. We should additionally check for the header value in X-Forwarded-Proto. We only redirect if not "https".