### PR TITLE
Remove unused require and make the plugin compatible with kong 1.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+lua_modules

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+DEV_ROCKS = busted luacheck lua-llthreads2
+BUSTED_ARGS ?= -o gtest -v --exclude-tags=ci
+TEST_CMD ?= bin/busted $(BUSTED_ARGS)
+KONG_PATH ?=/kong
+PLUGIN_NAME := kong-http-to-https-redirect
+
+.PHONY: install uninstall dev lint test test-integration test-plugins test-all clean
+
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+current_dir := $(dir $(mkfile_path))
+DEV_PACKAGE_PATH := $(current_dir)lua_modules/share/lua/5.1/?
+
+define set_env
+	@eval $$(luarocks path); \
+	LUA_PATH="$(DEV_PACKAGE_PATH).lua;$$LUA_PATH" LUA_CPATH="$(DEV_PACKAGE_PATH).so;$$LUA_CPATH"; \
+	cd $(KONG_PATH);
+endef
+
+lint:
+	@luacheck -q . \
+						--exclude-files 'kong/vendor/**/*.lua' \
+						--exclude-files 'spec/fixtures/invalid-module.lua' \
+						--std 'ngx_lua+busted' \
+						--globals '_KONG' \
+						--globals 'ngx' \
+						--globals 'assert' \
+						--no-redefined \
+						--no-unused-args
+
+install:
+	sudo luarocks make $(PLUGIN_NAME)-*.rockspec
+
+uninstall:
+	sudo luarocks remove $(PLUGIN_NAME)-*.rockspec
+
+install-dev:
+	luarocks make --tree lua_modules $(PLUGIN_NAME)-*.rockspec
+
+test: install-dev
+	$(call set_env) \
+	$(TEST_CMD) $(current_dir)spec/01-integration
+
+clean:
+	@echo "removing $(PLUGIN_NAME)"
+	-@luarocks remove --tree lua_modules $(PLUGIN_NAME)-*.rockspec >/dev/null 2>&1 ||:

--- a/kong-http-to-https-redirect-0.13.2-0.rockspec
+++ b/kong-http-to-https-redirect-0.13.2-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-http-to-https-redirect"
-version = "0.13.1-0"
+version = "0.13.2-0"
 source = {
     url = "git://github.com/HappyValleyIO/kong-http-to-https-redirect",
     branch = "master"

--- a/spec/01-integration/01-access_spec.lua
+++ b/spec/01-integration/01-access_spec.lua
@@ -1,0 +1,65 @@
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+  describe("Plugin: http-to-https-redirect (access) [#" .. strategy .. "]", function()
+    local proxy_client
+    local proxy_ssl_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy)
+
+      local route = bp.routes:insert {
+        hosts = { "example.com" },
+      }
+
+      bp.plugins:insert {
+        name  = "kong-http-to-https-redirect",
+        route = { id = route.id },
+      }
+
+      assert(helpers.start_kong({
+        database = strategy,
+        plugins = "bundled, kong-http-to-https-redirect",
+        custom_plugins = "kong-http-to-https-redirect",
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+
+      proxy_client = helpers.proxy_client()
+      proxy_ssl_client = helpers.proxy_ssl_client()
+    end)
+
+    it("is redirected when scheme is http", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          ["Host"] = "example.com",
+        }
+      })
+
+      assert.res_status(301, res)
+    end)
+
+    it("is not redirected when scheme is https", function()
+      local res = assert(proxy_ssl_client:send {
+        method  = "GET",
+        path    = "/",
+        headers = {
+          ["Host"]              = "example.com",
+          ["X-Forwarded-Proto"] = "https"
+        }
+      })
+
+      assert.res_status(200, res)
+    end)
+
+    lazy_teardown(function()
+      if proxy_client and proxy_ssl_client then
+        proxy_client:close()
+        proxy_ssl_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+  end)
+end

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -1,5 +1,4 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 
 local HttpFilterHandler = BasePlugin:extend()
 


### PR DESCRIPTION
Dear author,

It seems that `require "kong.tools.responses"` in src/handler.lua is useless. And `kong.tools.responses` is removed in kong 1.0.x (https://github.com/Kong/kong/blob/master/CHANGELOG.md#plugins-3).

So I just deleted that useless require statement, and added some test cases, and made the plugin compatible with kong 1.0.x.

@stepbeekio  @slimm609 